### PR TITLE
Fix compatibility issues and caching

### DIFF
--- a/plover_plugins_manager/plugin_metadata.py
+++ b/plover_plugins_manager/plugin_metadata.py
@@ -1,4 +1,3 @@
-
 from collections import namedtuple
 from functools import total_ordering
 
@@ -25,7 +24,7 @@ class PluginMetadata(namedtuple('PluginMetadata', '''
 
     @property
     def parsed_version(self):
-        return parse_version(self.version)
+        return parse_version(str(self.version or ""))
 
     @classmethod
     def from_dict(cls, d):

--- a/plover_plugins_manager/requests.py
+++ b/plover_plugins_manager/requests.py
@@ -3,22 +3,14 @@ import os
 from requests_futures.sessions import FuturesSession
 from requests_cache import CachedSession
 
-from plover.oslayer.config import CONFIG_DIR
-
-
-CACHE_NAME = os.path.join(CONFIG_DIR, '.cache', 'plugins')
 
 
 class CachedSession(CachedSession):
 
     def __init__(self):
-        dirname = os.path.dirname(CACHE_NAME)
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
-        super().__init__(cache_name=CACHE_NAME,
-                         backend='sqlite',
+        super().__init__(backend='memory',
                          expire_after=600)
-        self.remove_expired_responses()
+        self.cache.delete(expired=True)
 
 
 class CachedFuturesSession(FuturesSession):


### PR DESCRIPTION
* Fixes plugin version parsing: `pkginfo` now returns `packaging.version.Version` objects instead of plain strings
* Fixes #24
* Change caching from sqlite to memory since that's more robust

